### PR TITLE
Remove bottle :unneeded to fix error

### DIFF
--- a/Formula/xterrafile.rb
+++ b/Formula/xterrafile.rb
@@ -3,7 +3,6 @@ class Xterrafile < Formula
   desc "Systematically manage external modules from Github for use in Terraform."
   homepage "https://github.com/devopsmakers/xterrafile"
   version "2.3.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/devopsmakers/xterrafile/releases/download/v2.3.1/xterrafile_2.3.1_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Error -
```
▶ brew tap devopsmakers/xterrafile
==> Tapping devopsmakers/xterrafile
Cloning into '/usr/local/Homebrew/Library/Taps/devopsmakers/homebrew-xterrafile'...
remote: Enumerating objects: 106, done.
remote: Counting objects: 100% (32/32), done.
remote: Compressing objects: 100% (17/17), done.
remote: Total 106 (delta 7), reused 32 (delta 7), pack-reused 74
Receiving objects: 100% (106/106), 13.30 KiB | 801.00 KiB/s, done.
Resolving deltas: 100% (23/23), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/devopsmakers/homebrew-xterrafile/Formula/xterrafile.rb
xterrafile: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the devopsmakers/xterrafile tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/devopsmakers/homebrew-xterrafile/Formula/xterrafile.rb:6

Error: Cannot tap devopsmakers/xterrafile: invalid syntax in tap!
```